### PR TITLE
Fix code scanning alert no. 1: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_6/security/code-scanning/1](https://github.com/Brook-5686/Ruby_6/security/code-scanning/1)

To fix the problem, we need to strengthen the CSRF protection by modifying the `protect_from_forgery` method to raise an exception on an invalid CSRF token. This can be achieved by passing the `with: :exception` argument to the method. This change ensures that any invalid CSRF token will result in an exception, providing a more robust defense against CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
